### PR TITLE
Use keydown isntead of keypress

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,11 @@
+1.2.2
+  The keydown event is now used for input characters instead of keypress
+  Various internal code changes to use jQuery plugin best practices
+
 1.2.1
   Add a onKeyDetect callback being called if any key (even non-chars) is detected
   Changed default scanButtonKeyCode to false (it turned out, that the previous value of '0' was actually used by some scanners)
+
 1.2.0
   Add options startChar, ignoreIfFocusOn, scanButtonKeyCode, scanButtonLongPressThreshold
 

--- a/README.md
+++ b/README.md
@@ -25,45 +25,46 @@ See a detailed tutorial with presets for different scanner models and first step
 
 Options
 -------
-###onComplete 
+
+### onComplete 
 Callback after detection of a successful scanning
-###onError 
+### onError 
 Callback after detection of a unsuccessful scanning (scanned string in parameter)
-###onReceive 
+### onReceive 
 Callback after receiving and processing a char (scanned char in parameter)
-###onKeyDetect  
+### onKeyDetect  
 Callback after detecting a keyDown (key char in parameter) - in contrast to onReceive, this fires for non-character keys like tab, arrows, etc. too!
-###onScanButtonLongPressed  
+### onScanButtonLongPressed  
 Callback after detection of a successfull scan while the scan button was pressed and held down. This can only be used if the scan button behaves as a key itself (see scanButtonKeyCode). This long press event can be used to add a secondary action. For example, if the primary action is to count some items with barcodes (e.g. products at goods-in), it is comes very handy if a number pad pops up on the screen when the scan button is held. Large number can then be easily typed it instead of scanning fifty times in a row. 
 Note: this option requires scanButtonKeyCode to be set to a valid key code!
-###timeBeforeScanTest
+### timeBeforeScanTest
 Default: 100  
 Wait duration (ms) after keypress event to check if scanning is finished
-###avgTimeByChar
+### avgTimeByChar
 Default: 30  
 Average time (ms) between 2 chars. Used to do difference between keyboard typing and scanning
-###minLength
+### minLength
 Default: 6  
 Minimum length for a scanning
-###endChar
+### endChar
 Default: [9,13]  
 Chars to remove and means end of scanning
-###startChar
+### startChar
 Default: []  
 Chars to remove and means start of scanning
-###ignoreIfFocusOn
+### ignoreIfFocusOn
 Default: false  
 Ignore scans if the currently focused element matches this selector. Per example, if you set this option to 'input', scanner detection will be disable if an input is focused, when the scan occurs.
-###scanButtonKeyCode
+### scanButtonKeyCode
 Default: null  
 Key code of the scanner hardware button (if the scanner button a acts as a key itself). Knowing this key code is important, because it is not part of the scanned code and must be ignored. On the other hand, knowing it can be usefull: pressing the button multiple times fast normally results just in one scan, but you still could count the number of times pressed, allowing the user to input quantities this way (typical use case would be counting product at goods-in). 
-###scanButtonLongPressThreshold
+### scanButtonLongPressThreshold
 Default: 3  
 You can let the user perform some special action by pressing and holding the scan button. In this case the button will issue multiple keydown events. This parameter sets, how many sequential events should be interpreted as holding the button down.  
-###stopPropagation
+### stopPropagation
 Default: false  
 Stop immediate propagation on keypress event
-###preventDefault
+### preventDefault
 Default: false  
 Prevent default action on keypress event
 
@@ -79,16 +80,16 @@ Of course, events exist only if plugin is initialized on selector.
         .bind('scannerDetectionError',function(e,data){...})
         .bind('scannerDetectionReceive',function(e,data){...})
 
-###scannerDetectionComplete
+### scannerDetectionComplete
 Callback after detection of a successful scanning  
 Event data: {string: "scanned string"}
-###scannerDetectionError
+### scannerDetectionError
 Callback after detection of a unsuccessful scanning  
 Event data: {string: "scanned string"}  
-###scannerDetectionReceive
+### scannerDetectionReceive
 Callback after receive and process a char  
 Event data: {evt: {original keydown event}}
-###scannerDetectionKeyDetect
+### scannerDetectionKeyDetect
 Callback after detecting a keyDown - in contrast to onReceive, this fires for non-character keys like tab, arrows, etc. too!
 Event data: {evt: {original keydown event}}
 

--- a/README.md
+++ b/README.md
@@ -25,20 +25,15 @@ See a detailed tutorial with presets for different scanner models and first step
 
 Options
 -------
-###onComplete
-Default: false  
+###onComplete 
 Callback after detection of a successful scanning
-###onError
-Default: false  
+###onError 
 Callback after detection of a unsuccessful scanning (scanned string in parameter)
-###onReceive
-Default: false  
+###onReceive 
 Callback after receiving and processing a char (scanned char in parameter)
-###onKeyDetect
-Default: false  
+###onKeyDetect  
 Callback after detecting a keyDown (key char in parameter) - in contrast to onReceive, this fires for non-character keys like tab, arrows, etc. too!
-###onScanButtonLongPressed
-Default: false  
+###onScanButtonLongPressed  
 Callback after detection of a successfull scan while the scan button was pressed and held down. This can only be used if the scan button behaves as a key itself (see scanButtonKeyCode). This long press event can be used to add a secondary action. For example, if the primary action is to count some items with barcodes (e.g. products at goods-in), it is comes very handy if a number pad pops up on the screen when the scan button is held. Large number can then be easily typed it instead of scanning fifty times in a row. 
 Note: this option requires scanButtonKeyCode to be set to a valid key code!
 ###timeBeforeScanTest
@@ -60,7 +55,7 @@ Chars to remove and means start of scanning
 Default: false  
 Ignore scans if the currently focused element matches this selector. Per example, if you set this option to 'input', scanner detection will be disable if an input is focused, when the scan occurs.
 ###scanButtonKeyCode
-Default: false  
+Default: null  
 Key code of the scanner hardware button (if the scanner button a acts as a key itself). Knowing this key code is important, because it is not part of the scanned code and must be ignored. On the other hand, knowing it can be usefull: pressing the button multiple times fast normally results just in one scan, but you still could count the number of times pressed, allowing the user to input quantities this way (typical use case would be counting product at goods-in). 
 ###scanButtonLongPressThreshold
 Default: 3  
@@ -92,10 +87,10 @@ Callback after detection of a unsuccessful scanning
 Event data: {string: "scanned string"}  
 ###scannerDetectionReceive
 Callback after receive and process a char  
-Event data: {evt: {original keypress event}}
+Event data: {evt: {original keydown event}}
 ###scannerDetectionKeyDetect
 Callback after detecting a keyDown - in contrast to onReceive, this fires for non-character keys like tab, arrows, etc. too!
-Event data: {evt: {original keypress event}}
+Event data: {evt: {original keydown event}}
 
 Requirements
 ------------

--- a/jquery.scannerdetection.js
+++ b/jquery.scannerdetection.js
@@ -9,162 +9,274 @@
  * Project home:
  * https://github.com/julien-maurel/jQuery-Scanner-Detection
  *
- * Version: 1.2.1
+ * Version: 1.2.2
  *
  */
 (function($){
-    $.fn.scannerDetection=function(options){
+    $.fn.scannerDetection = function(options) {
 
         // If string given, call onComplete callback
-        if(typeof options==="string"){
-            this.each(function(){
+        if(typeof options === "string") {
+            return this.each(function(){
                 this.scannerDetectionTest(options);
             });
-            return this;
         }
-		
-	    // If false (boolean) given, deinitialize plugin
-	    if(options === false){
-	        this.each(function(){
-	    	    this.scannerDetectionOff();
-	        });
-	        return this;
-	    }
 
-        var defaults={
-            onComplete:false, // Callback after detection of a successfull scanning (scanned string in parameter)
-            onError:false, // Callback after detection of a unsuccessfull scanning (scanned string in parameter)
-            onReceive:false, // Callback after receiving and processing a char (scanned char in parameter)
-            onKeyDetect:false, // Callback after detecting a keyDown (key char in parameter) - in contrast to onReceive, this fires for non-character keys like tab, arrows, etc. too!
-            timeBeforeScanTest:100, // Wait duration (ms) after keypress event to check if scanning is finished
-            avgTimeByChar:30, // Average time (ms) between 2 chars. Used to do difference between keyboard typing and scanning
-            minLength:6, // Minimum length for a scanning
-            endChar:[9,13], // Chars to remove and means end of scanning
-	        startChar:[], // Chars to remove and means start of scanning
-	        ignoreIfFocusOn:false, // do not handle scans if the currently focused element matches this selector
-	        scanButtonKeyCode:false, // Key code of the scanner hardware button (if the scanner button a acts as a key itself) 
-	        scanButtonLongPressThreshold:3, // How many times the hardware button should issue a pressed event before a barcode is read to detect a longpress
-            onScanButtonLongPressed:false, // Callback after detection of a successfull scan while the scan button was pressed and held down
-            stopPropagation:false, // Stop immediate propagation on keypress event
-            preventDefault:false // Prevent default action on keypress event
-        };
-        if(typeof options==="function"){
-            options={onComplete:options}
+        // If false (boolean) given, deinitialize plugin
+        if(options === false) {
+            return this.each(function(){
+                this.scannerDetectionOff();
+            });
         }
-        if(typeof options!=="object"){
-            options=$.extend({},defaults);
-        }else{
-            options=$.extend({},defaults,options);
+
+        if(typeof options === "function"){
+            options = {onComplete: options};
         }
-        
-        this.each(function(){
-            var self=this, $self=$(self), firstCharTime=0, lastCharTime=0, stringWriting='', callIsScanner=false, testTimer=false, scanButtonCounter=0;
-            var initScannerDetection=function(){
-                firstCharTime=0;
-                stringWriting='';
-		        scanButtonCounter=0;
+
+        var settings = $.extend({
+            onComplete: function() {}, // Callback after detection of a successful scanning (scanned string in parameter)
+            onError: function() {}, // Callback after detection of a unsuccessful scanning (scanned string in parameter)
+            onReceive: function() {}, // Callback after receiving and processing a char (scanned char in parameter)
+            onKeyDetect: function() {}, // Callback after detecting a keyDown (key char in parameter) - in contrast to onReceive, this fires for non-character keys like tab, arrows, etc. too!
+            timeBeforeScanTest: 100, // Wait duration (ms) after keydown event to check if scanning is finished
+            avgTimeByChar: 30, // Average time (ms) between 2 chars. Used to do difference between keyboard typing and scanning
+            minLength: 6, // Minimum length for a scanning
+            endChar: [9,13], // Chars to remove and means end of scanning
+            startChar: [], // Chars to remove and means start of scanning
+            ignoreIfFocusOn: false, // do not handle scans if the currently focused element matches this selector
+            scanButtonKeyCode: null, // Key code of the scanner hardware button (if the scanner button a acts as a key itself)
+            scanButtonLongPressThreshold: 3, // How many times the hardware button should issue a pressed event before a barcode is read to detect a longpress
+            onScanButtonLongPressed: function() {}, // Callback after detection of a successful scan while the scan button was pressed and held down
+            stopPropagation: false, // Stop immediate propagation on keydown event
+            preventDefault: false // Prevent default action on keydown event
+        }, options || {});
+
+        function getCharacter(e) {
+            /*** Convert to Char Code ***/
+            var code = e.which;
+
+            //Ignore Shift Key events & arrows
+            var ignoredCodes = {
+                16: true,
+                37: true,
+                38: true,
+                39: true,
+                40: true,
+                20: true,
+                17: true,
+                18: true,
+                91: true
             };
-	        self.scannerDetectionOff=function(){
-		    $self.unbind('keydown.scannerDetection');
-		    $self.unbind('keypress.scannerDetection');
-	    }
-	    self.isFocusOnIgnoredElement=function(){
-            if(!options.ignoreIfFocusOn) return false;
-		    if(typeof options.ignoreIfFocusOn === 'string') return $(':focus').is(options.ignoreIfFocusOn);
-	        if(typeof options.ignoreIfFocusOn === 'object' && options.ignoreIfFocusOn.length){
-		        var focused=$(':focus');
-		        for(var i=0; i<options.ignoreIfFocusOn.length; i++){
-			        if(focused.is(options.ignoreIfFocusOn[i])){
-			            return true;
-			        }
-		        }
-		    }
-		    return false;
-	    }
-        self.scannerDetectionTest=function(s){
-            // If string is given, test it
-            if(s){
-                firstCharTime=lastCharTime=0;
-                stringWriting=s;
+
+            if(ignoredCodes[code] === true) {
+                return false;
             }
 
-		    if (!scanButtonCounter){
-		        scanButtonCounter = 1;
-		    }
+            //These are special cases that don't fit the ASCII mapping
+            var exceptions = {
+                186: 59, // ;
+                187: 61, // =
+                188: 44, // ,
+                189: 45, // -
+                190: 46, // .
+                191: 47, // /
+                192: 96, // `
+                219: 91, // [
+                220: 92, // \
+                221: 93, // ]
+                222: 39, // '
+                //numeric keypad
+                96: '0'.charCodeAt(0),
+                97: '1'.charCodeAt(0),
+                98: '2'.charCodeAt(0),
+                99: '3'.charCodeAt(0),
+                100: '4'.charCodeAt(0),
+                101: '5'.charCodeAt(0),
+                102: '6'.charCodeAt(0),
+                103: '7'.charCodeAt(0),
+                104: '8'.charCodeAt(0),
+                105: '9'.charCodeAt(0)
+            };
 
-			// If all condition are good (length, time...), call the callback and re-initialize the plugin for next scanning
-			// Else, just re-initialize
-			if(stringWriting.length>=options.minLength && lastCharTime-firstCharTime<stringWriting.length*options.avgTimeByChar){
-		        if(options.onScanButtonLongPressed && scanButtonCounter > options.scanButtonLongPressThreshold) options.onScanButtonLongPressed.call(self,stringWriting,scanButtonCounter);
-                    else if(options.onComplete) options.onComplete.call(self,stringWriting,scanButtonCounter);
-                    $self.trigger('scannerDetectionComplete',{string:stringWriting});
-                    initScannerDetection();
-                    return true;
-                }else{
-                    if(options.onError) options.onError.call(self,stringWriting);
-                    $self.trigger('scannerDetectionError',{string:stringWriting});
-                    initScannerDetection();
+            if(exceptions[code] !== undefined) {
+                code = exceptions[code];
+            }
+
+            var ch = String.fromCharCode(code);
+
+            /*** Handle Shift ***/
+            if(e.shiftKey) {
+                var special = {
+                    1: '!',
+                    2: '@',
+                    3: '#',
+                    4: '$',
+                    5: '%',
+                    6: '^',
+                    7: '&',
+                    8: '*',
+                    9: '(',
+                    0: ')',
+                    ',': '<',
+                    '.': '>',
+                    '/': '?',
+                    ';': ':',
+                    "'": '"',
+                    '[': '{',
+                    ']': '}',
+                    '\\': '|',
+                    '`': '~',
+                    '-': '_',
+                    '=': '+'
+                };
+
+                if(special[ch] !== undefined) {
+                    ch = special[ch];
+                }
+            }
+            else {
+                ch = ch.toLowerCase();
+            }
+            return ch;
+        }
+
+        this.each(function() {
+            var self = this,
+                $self = $(self),
+                firstCharTime = 0,
+                lastCharTime = 0,
+                stringWriting = '',
+                callIsScanner = false,
+                testTimer = false,
+                scanButtonCounter = 0;
+
+            self.initScannerDetection = function() {
+                firstCharTime = 0;
+                stringWriting = '';
+                scanButtonCounter = 0;
+            };
+
+            self.isFocusOnIgnoredElement = function() {
+                if (!settings.ignoreIfFocusOn) {
                     return false;
                 }
-            }
-            $self.data('scannerDetection',{options:options}).unbind('.scannerDetection').bind('keydown.scannerDetection',function(e){
-			    // If it's just the button of the scanner, ignore it and wait for the real input
-		        if(options.scanButtonKeyCode !== false && e.which==options.scanButtonKeyCode) {
-                    scanButtonCounter++;
-                    // Cancel default
-                    e.preventDefault();
-                    e.stopImmediatePropagation();
+                if(typeof settings.ignoreIfFocusOn === 'string') {
+                    return $(':focus').is(options.ignoreIfFocusOn);
                 }
-		        // Add event on keydown because keypress is not triggered for non character keys (tab, up, down...)
-                // So need that to check endChar and startChar (that is often tab or enter) and call keypress if necessary
-                else if((firstCharTime && options.endChar.indexOf(e.which)!==-1) 
-			    || (!firstCharTime && options.startChar.indexOf(e.which)!==-1)){
-                    // Clone event, set type and trigger it
-                    var e2=jQuery.Event('keypress',e);
-                    e2.type='keypress.scannerDetection';
-                    $self.triggerHandler(e2);
-                    // Cancel default
-                    e.preventDefault();
-                    e.stopImmediatePropagation();
-                }
-                // Fire keyDetect event in any case!
-                if(options.onKeyDetect) options.onKeyDetect.call(self,e);
-                $self.trigger('scannerDetectionKeyDetect',{evt:e});
-				
-            }).bind('keypress.scannerDetection',function(e){
-		        if (this.isFocusOnIgnoredElement()) return;
-                if(options.stopPropagation) e.stopImmediatePropagation();
-                if(options.preventDefault) e.preventDefault();
 
-                if(firstCharTime && options.endChar.indexOf(e.which)!==-1){
-                    e.preventDefault();
-                    e.stopImmediatePropagation();
-                    callIsScanner=true;
-                }else if(!firstCharTime && options.startChar.indexOf(e.which)!==-1){
-                    e.preventDefault();
-                    e.stopImmediatePropagation();
-		            callIsScanner=false;
-		        }else{
-                    if (typeof(e.which) != 'undefined'){
-                        stringWriting+=String.fromCharCode(e.which);
+                if(typeof settings.ignoreIfFocusOn === 'object' && settings.ignoreIfFocusOn.length > 0) {
+                    var focused=$(':focus');
+                    for(var i=0; i<settings.ignoreIfFocusOn.length; i++){
+                        if(focused.is(settings.ignoreIfFocusOn[i])){
+                            return true;
+                        }
                     }
-                    callIsScanner=false;
                 }
 
-                if(!firstCharTime){
-                    firstCharTime=Date.now();
-                }
-                lastCharTime=Date.now();
+                return false;
+            };
 
-                if(testTimer) clearTimeout(testTimer);
-                if(callIsScanner){
+            self.scannerDetectionOff = function() {
+                $self.unbind('keydown.scannerDetection');
+                $self.unbind('keypress.scannerDetection');
+            };
+
+            self.scannerDetectionTest = function(s) {
+                // If string is given, test it
+                if (s) {
+                    firstCharTime = lastCharTime = 0;
+                    stringWriting = s;
+                }
+
+                if (!scanButtonCounter) {
+                    scanButtonCounter = 1;
+                }
+
+                var scanDuration = lastCharTime - firstCharTime;
+                var scanDurationThreshold = stringWriting.length * settings.avgTimeByChar;
+
+                // If the scan was long enough and done fast enough, it was a successful scan. Otherwise, error.
+                if (stringWriting.length >= settings.minLength && scanDuration <= scanDurationThreshold) {
+                    if (scanButtonCounter > settings.scanButtonLongPressThreshold) {
+                        settings.onScanButtonLongPressed.call(self, stringWriting, scanButtonCounter);
+                    } else {
+                        settings.onComplete.call(self, stringWriting, scanButtonCounter);
+                    }
+                    $self.trigger('scannerDetectionComplete', {string: stringWriting});
+                    self.initScannerDetection();
+                    return true;
+                } else {
+                    settings.onError.call(self, stringWriting);
+                    $self.trigger('scannerDetectionError', {string: stringWriting});
+                    self.initScannerDetection();
+                    return false;
+                }
+            };
+
+            $self.unbind('.scannerDetection');
+
+            $self.bind('keydown.scannerDetection', function(e) {
+                // If it's just the button of the scanner, ignore it and wait for the real input
+                if(settings.scanButtonKeyCode !== null && e.which === settings.scanButtonKeyCode) {
+                    scanButtonCounter++;
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                }
+
+                settings.onKeyDetect.call(self,e);
+                $self.trigger('scannerDetectionKeyDetect',{evt:e});
+
+                if (this.isFocusOnIgnoredElement()) {
+                    return;
+                }
+
+                if (settings.stopPropagation) {
+                    e.stopImmediatePropagation();
+                }
+
+                if (settings.preventDefault) {
+                    e.preventDefault();
+                }
+
+                // If it's not the first character and we encounter a terminating character, trigger scan process
+                if (firstCharTime && settings.endChar.indexOf(e.which) !== -1){
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    callIsScanner = true;
+
+                // If it's the first character and we encountered one of the starting characters, don't process the scan
+                } else if(!firstCharTime && settings.startChar.indexOf(e.which) !== -1){
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    callIsScanner = false;
+
+                // Otherwise, just add the character to the scan string we're building
+                } else {
+                    var character = getCharacter(e);
+                    if (character !== false){
+                        stringWriting += character;
+                    }
+                    callIsScanner = false;
+                }
+
+                if (!firstCharTime) {
+                    firstCharTime = Date.now();
+                }
+
+                lastCharTime = Date.now();
+
+                if (testTimer) {
+                    clearTimeout(testTimer);
+                }
+
+                if (callIsScanner) {
                     self.scannerDetectionTest();
                     testTimer=false;
-                }else{
-                    testTimer=setTimeout(self.scannerDetectionTest,options.timeBeforeScanTest);
+                } else {
+                    testTimer=setTimeout(self.scannerDetectionTest,settings.timeBeforeScanTest);
                 }
 
-                if(options.onReceive) options.onReceive.call(self,e);
+                settings.onReceive.call(self,e);
                 $self.trigger('scannerDetectionReceive',{evt:e});
             });
         });


### PR DESCRIPTION
The keypress event is deprecated according to the [DOM Level 3 Spec](https://www.w3.org/TR/DOM-Level-3-Events/#event-type-keypress). In my testing, newer Android devices running Chrome are no longer triggering the keypress, only keydown and keyup. My fork modifies this library to rely only on keydown. The existing code relied both on the keypress and keydown events to handle special button presses, and with my modification this is no longer necessary.

Also updated are code formatting changes, updating various things to conform to jQuery plugin best practices, and fixing formatting issues in the documentation. The library's API was not affected by any of these changes.